### PR TITLE
fix: Remove invalid 'releases' permission from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,6 @@ on:
 
 permissions:
   contents: write
-  releases: write
 
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1


### PR DESCRIPTION
GitHub Actions doesn't recognize 'releases' as a valid permission.
The workflow can create releases using the 'contents: write' permission
which is sufficient for creating GitHub releases via ncipollo/release-action.

This resolves the workflow file validation error:
"(Line: 17, Col: 3): Unexpected value 'releases'"